### PR TITLE
Rename groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ How many times have you been working on a feature with 20 different editor tabs 
 
 ## Features
 
-Quickly save a list of all open Editor tabs and place them into an easily managed view. From there, you can see a preview of the files, restore them back into tabs, or remove the reference list from the view. 
+Quickly save a list of all open Editor tabs and place them into an easily managed view. From there, you can see a preview of the files, restore them back into tabs, rename the group for better organization, or remove the reference list from the view.
 
 > Note: This does not save or edit the files within the list. It only saves, restores, and removes the references from the view. The files will remain untouched.
 
@@ -21,6 +21,10 @@ Quickly save a list of all open Editor tabs and place them into an easily manage
  - VSCode doesn't support direct tab access via the API so options of what we can do is limited.
 
 ## Release Notes
+
+### 1.1.0
+
+- [Issue #5](https://github.com/suhay/vscode-editor-group-minimizer/issues/5): Rename minimized groups
 
 ### 1.0.3
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "displayName": "Editor Group Minimizer",
   "description": "Minimize groups of editor tabs in VSCode",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "engines": {
     "vscode": "^1.44.0"
   },

--- a/package.json
+++ b/package.json
@@ -57,6 +57,10 @@
           "light": "resources/light/clear.svg",
           "dark": "resources/dark/clear.svg"
         }
+      },
+      {
+        "command": "vscode-editor-group-minimizer.rename",
+        "title": "Rename"
       }
     ],
     "menus": {
@@ -82,6 +86,10 @@
         },
         {
           "command": "vscode-editor-group-minimizer.restore",
+          "when": "view == minimizedGroups && viewItem == editorGroup"
+        },
+        {
+          "command": "vscode-editor-group-minimizer.rename",
           "when": "view == minimizedGroups && viewItem == editorGroup"
         }
       ]

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "displayName": "Editor Group Minimizer",
   "description": "Minimize groups of editor tabs in VSCode",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "engines": {
     "vscode": "^1.44.0"
   },

--- a/src/editorGroup.ts
+++ b/src/editorGroup.ts
@@ -5,7 +5,7 @@ export class EditorGroup extends vscode.TreeItem {
   description: string;
 
   constructor(
-    public readonly label: string,
+    public label: string,
     public readonly collapsibleState?: vscode.TreeItemCollapsibleState,
     public readonly documents?: vscode.TextDocument[]
   ) {

--- a/src/editorGroupTreeDataProvider.ts
+++ b/src/editorGroupTreeDataProvider.ts
@@ -85,4 +85,19 @@ export class EditorGroupTreeDataProvider implements vscode.TreeDataProvider<Edit
   clear(): Thenable<void> {
     return this.context.workspaceState.update('minimizedGroups', undefined);
   }
+
+  async rename(group: EditorGroup): Promise<void> {
+    return vscode.window.showInputBox()
+      .then((value) => {
+        const minimizedGroups = this.context.workspaceState.get<Array<EditorGroup>>('minimizedGroups') || [];
+        const oldGroup = minimizedGroups.find((mGroup) => mGroup === group);
+
+        if (oldGroup && value && value !== '') {
+          oldGroup.label = value;
+        }
+
+        return this.context.workspaceState.update('minimizedGroups', minimizedGroups);
+      })
+      .then(() => this.refresh());
+  }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,6 +8,7 @@ export function activate(context: vscode.ExtensionContext) {
   vscode.commands.registerCommand('vscode-editor-group-minimizer.minimize', () => editorGroupTreeDataProvider.minimize());
   vscode.commands.registerCommand('vscode-editor-group-minimizer.remove', group => editorGroupTreeDataProvider.remove(group));
   vscode.commands.registerCommand('vscode-editor-group-minimizer.restore', group => editorGroupTreeDataProvider.restore(group));
+  vscode.commands.registerCommand('vscode-editor-group-minimizer.rename', group => editorGroupTreeDataProvider.rename(group));
 
   context.subscriptions.push(editorGroupTreeDataProvider);
 }


### PR DESCRIPTION
Closes #5 

Renaming can now be done by right clicking the group within the TreeView. Releasing as apart of v1.1.0.