### PR TITLE
Adds optional prompt for group name

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,16 @@
         "title": "Remove from Group"
       }
     ],
+    "configuration": {
+      "title": "Editor Group Minimizer",
+      "properties": {
+        "editorGroupMinimizer.groupNamePrompt": {
+          "type": "boolean",
+          "default": false,
+          "description": "Prompt for the desired name of the group when minimized."
+        }
+      }
+    },
     "menus": {
       "editor/title/context": [
         {

--- a/src/editorGroupTreeDataProvider.ts
+++ b/src/editorGroupTreeDataProvider.ts
@@ -2,15 +2,18 @@ import * as vscode from 'vscode';
 
 import { EditorDocument } from './editorDocument';
 import { EditorGroup } from './editorGroup';
+import { ExtensionConfiguration } from './extensionConfiguration';
 
 export class EditorGroupTreeDataProvider implements vscode.TreeDataProvider<EditorGroup> {
 	private _onDidChangeTreeData: vscode.EventEmitter<EditorGroup | undefined> = new vscode.EventEmitter<EditorGroup | undefined>();
   readonly onDidChangeTreeData: vscode.Event<EditorGroup | undefined> = this._onDidChangeTreeData.event;
   
   context: vscode.ExtensionContext;
+  configuration: ExtensionConfiguration;
 
   constructor(cont: vscode.ExtensionContext) {
     this.context = cont;
+    this.configuration = new ExtensionConfiguration();
   }
 
 	refresh(): void {
@@ -65,6 +68,10 @@ export class EditorGroupTreeDataProvider implements vscode.TreeDataProvider<Edit
   }
 
   async minimize(): Promise<void> {
+    const providedLabel = this.configuration.prompt ? await vscode.window.showInputBox({
+      prompt: 'Provide group name or leave empty for default.'
+    }) : undefined;
+
     const documents: EditorDocument[] = [];
     const minimizedGroups = this.context.workspaceState.get<Array<EditorGroup>>('minimizedGroups') || [];
     let activeTextEditor = vscode.window.activeTextEditor;
@@ -95,7 +102,7 @@ export class EditorGroupTreeDataProvider implements vscode.TreeDataProvider<Edit
       pinnedCheck = activeTextEditor;
     }
 
-    const label = `Group ${minimizedGroups.length + 1}`;
+    const label = providedLabel && providedLabel.length ? providedLabel : `Group ${minimizedGroups.length + 1}`;
     minimizedGroups.push(new EditorGroup(
       label, 
       vscode.TreeItemCollapsibleState.Collapsed, 

--- a/src/extensionConfiguration.ts
+++ b/src/extensionConfiguration.ts
@@ -1,0 +1,14 @@
+import * as vscode from 'vscode';
+
+export class ExtensionConfiguration {
+  public prompt: boolean = false;
+
+  constructor() {
+    vscode.workspace.onDidChangeConfiguration(() => this.init());
+    this.init();
+  }
+
+  init() {
+    this.prompt = vscode.workspace.getConfiguration('editorGroupMinimizer').get<boolean>('groupNamePrompt') || false;
+  }
+}


### PR DESCRIPTION
Implements #33.

- adds configuration contribution to extension
- adds configuration class to extension to manage configuration access and update
- updates the editor group tree data provider `minimize()` method to optionally prompt for a group name if enabled in configuration

