### PR TITLE
Feat update group

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,11 @@
         "title": "Minimize Editor Group"
       },
       {
+        "command": "vscode-editor-group-minimizer.updateMinimizeGroup",
+        "title": "Updated Minimized Editor Group",
+        "enablement": "vscode-editor-group-minimizer.lengthMinimizedGroups > 0"
+      },
+      {
         "command": "vscode-editor-group-minimizer.restore",
         "title": "Restore",
         "icon": {
@@ -90,6 +95,9 @@
       "editor/title": [
         {
           "command": "vscode-editor-group-minimizer.minimize"
+        },
+        {
+          "command": "vscode-editor-group-minimizer.updateMinimizeGroup"
         }
       ],
       "view/item/context": [

--- a/package.json
+++ b/package.json
@@ -71,6 +71,16 @@
         "title": "Remove from Group"
       }
     ],
+    "configuration": {
+      "title": "Editor Group Minimizer",
+      "properties": {
+        "editorGroupMinimizer.groupNamePrompt": {
+          "type": "boolean",
+          "default": false,
+          "description": "Prompt for the desired name of the group when minimized."
+        }
+      }
+    },
     "menus": {
       "editor/title/context": [
         {

--- a/src/editorGroupTreeDataProvider.ts
+++ b/src/editorGroupTreeDataProvider.ts
@@ -2,15 +2,18 @@ import * as vscode from 'vscode';
 
 import { EditorDocument } from './editorDocument';
 import { EditorGroup } from './editorGroup';
+import { ExtensionConfiguration } from './extensionConfiguration';
 
 export class EditorGroupTreeDataProvider implements vscode.TreeDataProvider<EditorGroup> {
 	private _onDidChangeTreeData: vscode.EventEmitter<EditorGroup | undefined> = new vscode.EventEmitter<EditorGroup | undefined>();
   readonly onDidChangeTreeData: vscode.Event<EditorGroup | undefined> = this._onDidChangeTreeData.event;
   
   context: vscode.ExtensionContext;
+  configuration: ExtensionConfiguration;
 
   constructor(cont: vscode.ExtensionContext) {
     this.context = cont;
+    this.configuration = new ExtensionConfiguration();
   }
 
 	refresh(): void {
@@ -65,6 +68,10 @@ export class EditorGroupTreeDataProvider implements vscode.TreeDataProvider<Edit
   }
 
   async minimize(): Promise<void> {
+    const providedLabel = this.configuration.prompt ? await vscode.window.showInputBox({
+      prompt: 'Provide group name or leave empty for default.'
+    }) : undefined;
+
     const documents: EditorDocument[] = [];
     const minimizedGroups = this.context.workspaceState.get<Array<EditorGroup>>('minimizedGroups') || [];
     let activeTextEditor = vscode.window.activeTextEditor;
@@ -95,7 +102,7 @@ export class EditorGroupTreeDataProvider implements vscode.TreeDataProvider<Edit
       pinnedCheck = activeTextEditor;
     }
 
-    const label = `Group ${minimizedGroups.length + 1}`;
+    const label = providedLabel && providedLabel.length ? providedLabel : `Group ${minimizedGroups.length + 1}`;
     minimizedGroups.push(new EditorGroup(
       label, 
       vscode.TreeItemCollapsibleState.Collapsed, 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,6 +11,8 @@ export function activate(context: vscode.ExtensionContext) {
   vscode.commands.registerCommand('vscode-editor-group-minimizer.rename', group => editorGroupTreeDataProvider.rename(group));
   vscode.commands.registerCommand('vscode-editor-group-minimizer.addToGroup', uri => editorGroupTreeDataProvider.addToGroup(uri));
   vscode.commands.registerCommand('vscode-editor-group-minimizer.removeFromGroup', group => editorGroupTreeDataProvider.removeFromGroup(group));
+  vscode.commands.registerCommand('vscode-editor-group-minimizer.updateMinimizeGroup', () => editorGroupTreeDataProvider.updateMinimizeGroup());
+  vscode.commands.executeCommand('setContext', 'vscode-editor-group-minimizer.lengthMinimizedGroups', editorGroupTreeDataProvider.minimizedGroups.length);
 
   context.subscriptions.push(editorGroupTreeDataProvider);
 }

--- a/src/extensionConfiguration.ts
+++ b/src/extensionConfiguration.ts
@@ -1,0 +1,14 @@
+import * as vscode from 'vscode';
+
+export class ExtensionConfiguration {
+  public prompt: boolean = false;
+
+  constructor() {
+    vscode.workspace.onDidChangeConfiguration(() => this.init());
+    this.init();
+  }
+
+  init() {
+    this.prompt = vscode.workspace.getConfiguration('editorGroupMinimizer').get<boolean>('groupNamePrompt') || false;
+  }
+}


### PR DESCRIPTION
Supersedes and closes #34. I wanted to refactor several core functions from promises to `async`/`await` style in order to also consolidate some of the code. Since there were overlapping changes in both of my feature branches, I decided to merge the changes for #33 into those for this new PR.

---

Implements #33.

- adds configuration contribution to extension
- adds configuration class to extension to manage configuration access and update
- updates the editor group tree data provider `minimize()` method to optionally prompt for a group name if enabled in configuration

Implements possible solution for #20 

- adds new command contribution to extension for "update minimized group" functionality with enablement based on the number of minimized groups being greater than 0
- adds new title menu contribution pointing to new update command
- adds context item and update logic to support new command enablement
- updates `minimize()` function to be optionally called with new `update: boolean` parameter in signature which will prompt for the group to update


Please let me know if there are any questions/concerns.